### PR TITLE
ci: fix workflow by installing myst_parser for Sphinx

### DIFF
--- a/.github/workflows/host_docs.yaml
+++ b/.github/workflows/host_docs.yaml
@@ -29,7 +29,7 @@ jobs:
           python -m pip install sphinx-rtd-theme
           # python -m pip install sphinxcontrib-apidoc
           python -m pip install sphinx-autoapi
-          python -m install myst_parser
+          python -m pip install myst_parser
 
       - name: make the sphinx docs
         run: |


### PR DESCRIPTION
Added the installation of `myst_parser` to the CI workflow to resolve an issue preventing the documentation build from running correctly. This parser allows Markdown support in Sphinx, enhancing the flexibility and readability of the documentation.

- Updated CI configuration to include `python -m install myst_parser`.
- Ensured successful build and upload of Sphinx documentation.

This fix addresses the workflow problem and ensures continuous and automated updates of WML documentation.